### PR TITLE
Clean up othello

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,6 @@
             :selected-result="selectedResult"
             :user-input="userInput"
             :send-text-message="sendTextMessage"
-            @update:user-input="userInput = $event"
           />
           <BrowseView :selected-result="selectedResult" />
           <MulmocastView :selected-result="selectedResult" />
@@ -408,8 +407,8 @@ async function startChat(): Promise<void> {
   }
 }
 
-function sendTextMessage(): void {
-  const text = userInput.value.trim();
+function sendTextMessage(providedText?: string): void {
+  const text = (providedText || userInput.value).trim();
   if (!text) return;
 
   const dc = webrtc.dc;
@@ -444,7 +443,9 @@ function sendTextMessage(): void {
   );
 
   messages.value.push(`You: ${text}`);
-  userInput.value = "";
+  if (!providedText) {
+    userInput.value = "";
+  }
 }
 
 function handleSelectResult(result: ToolResult): void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,6 @@
           <ExaView :selected-result="selectedResult" />
           <OthelloView
             :selected-result="selectedResult"
-            :user-input="userInput"
             :send-text-message="sendTextMessage"
           />
           <BrowseView :selected-result="selectedResult" />

--- a/src/tools/views/othello.vue
+++ b/src/tools/views/othello.vue
@@ -47,7 +47,6 @@ import type { ToolResult } from "../type";
 
 const props = defineProps<{
   selectedResult: ToolResult | null;
-  userInput: string;
   sendTextMessage: (text?: string) => void;
 }>();
 

--- a/src/tools/views/othello.vue
+++ b/src/tools/views/othello.vue
@@ -48,11 +48,7 @@ import type { ToolResult } from "../type";
 const props = defineProps<{
   selectedResult: ToolResult | null;
   userInput: string;
-  sendTextMessage: () => void;
-}>();
-
-const emit = defineEmits<{
-  "update:user-input": [value: string];
+  sendTextMessage: (text?: string) => void;
 }>();
 
 const gameState = ref<any>(null);
@@ -138,11 +134,9 @@ function handleCellClick(index: number): void {
   const columnLetter = String.fromCharCode(65 + cell.col);
   const rowNumber = cell.row + 1;
 
-  emit(
-    "update:user-input",
+  props.sendTextMessage(
     `I want to play at ${columnLetter}${rowNumber}, which is column=${cell.col}, row=${cell.row} `,
   );
-  props.sendTextMessage();
 }
 
 function handleCellHover(index: number, isEntering: boolean): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now send preset messages directly from tools without typing; the input field only clears when sending manually typed text.
  - In the Othello view, clicking a cell automatically generates and sends a move message, streamlining gameplay interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->