### PR TITLE
Skip PDF generation if not available

### DIFF
--- a/server/routes/pdf.ts
+++ b/server/routes/pdf.ts
@@ -14,6 +14,24 @@ const router: Router = express.Router();
 const isCI = process.env.CI === "true";
 
 // PDF summarization endpoint using Claude
+router.get("/check-pdf", async (req: Request, res: Response): Promise<void> => {
+  let browser = null;
+  let available = true;
+  try {
+    browser = await puppeteer.launch({
+      args: isCI ? ["--no-sandbox"] : [],
+    });
+  } catch (error) {
+    console.error("PDF capability check failed:", error);
+    available = false;
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+  res.json({ available });
+});
+
 router.post(
   "/summarize-pdf",
   async (req: Request, res: Response): Promise<void> => {

--- a/src/tools/views/markdown.vue
+++ b/src/tools/views/markdown.vue
@@ -157,6 +157,17 @@ watch(
     )
       return;
 
+    try {
+      const pdfFeature = await fetch("/api/check-pdf", { method: "GET" });
+      const pdfResult = await pdfFeature.json();
+      if (!pdfResult.available) {
+        return;
+      }
+    } catch (error) {
+      console.error("PDF feature check exception:", error);
+      return;
+    }
+
     isGeneratingPdf.value = true;
     pdfError.value = null;
 


### PR DESCRIPTION
Resolves #41.

When generating reports on Ubuntu 24.04, PDF generation fails with the following error. This PR provides functionality to skip PDF generation when it is unavailable.

```
PDF generation failed: Failed to launch the browser process: Code: null stderr: [33334:33334:1227/082056.520539:FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc:132] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox. Received signal 6 #0 0x58964fccf95a (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x4121959) #1 0x58965683a674 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0xac8c673) #2 0x75ebaa645330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f) #3 0x75ebaa64527e (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4527d) #4 0x75ebaa6288ff (/usr/lib/x86_64-linux-gnu/libc.so.6+0x288fe) #5 0x589656832a85 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0xac84a84) #6 0x5896567f916d (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0xac4b16c) #7 0x5896567f90c6 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0xac4b0c5) #8 0x5896503d96f2 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x482b6f1) #9 0x58965216dbd9 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x65bfbd8) #10 0x58965003f106 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x4491105) #11 0x589655cc7b3f (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0xa119b3e) #12 0x589651cc57f1 (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x61177f0) #13 0x589650e0b6bf (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x525d6be) #14 0x75ebaa62a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) #15 0x75ebaa62a28b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) #16 0x589652cf2e5a (/home/honma/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome+0x7144e59) r8: 00003200000c0265 r9: 0000000000000001 r10: 0000000000000008 r11: 0000000000000246 r12: 0000000000000006 r13: 0000000000000266 r14: 0000000000000016 r15: 00007ffe940c52b8 di: 0000000000008236 si: 0000000000008236 bp: 00007ffe940c4c30 bx: 0000000000008236 dx: 0000000000000006 ax: 0000000000000000 cx: 000075ebaa69eb2c sp: 00007ffe940c4bf0 ip: 000075ebaa69eb2c efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000 [end of stack trace] TROUBLESHOOTING: https://pptr.dev/troubleshooting
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown viewer now performs a pre-check for PDF export availability and aborts generation if unavailable or the check fails, preventing failed exports and improving reliability.
  * Backend now exposes a PDF availability check so the viewer can verify service accessibility before attempting PDF generation, reducing user errors and wasted time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->