### PR TITLE
refactor: プラグインからバックエンド設定を隠蔽

### DIFF
--- a/src/tools/backend/index.ts
+++ b/src/tools/backend/index.ts
@@ -8,6 +8,13 @@ export {
   generateImageCommon,
   generateImage,
   editImage,
+  getRawImageConfig,
+  normalizeImageConfig,
+} from "./imageGeneration";
+export type {
+  NormalizedImageConfig,
+  ImageGenerationOptions,
+  ImageGenerationContext,
 } from "./imageGeneration";
 
 // Browse
@@ -23,8 +30,12 @@ export type {
 } from "./exa";
 
 // HTML generation
-export { generateHtml } from "./html";
-export type { HtmlGenerationParams, HtmlGenerationResponse } from "./html";
+export { generateHtml, getRawHtmlConfig, normalizeHtmlConfig } from "./html";
+export type {
+  HtmlBackend,
+  HtmlGenerationParams,
+  HtmlGenerationResponse,
+} from "./html";
 
 // PDF
 export { summarizePdf } from "./pdf";

--- a/src/tools/models/editHtml.ts
+++ b/src/tools/models/editHtml.ts
@@ -3,7 +3,6 @@ import HtmlView from "../views/html.vue";
 import HtmlPreview from "../previews/html.vue";
 import HtmlGenerationConfig from "../configs/HtmlGenerationConfig.vue";
 import type { HtmlToolData } from "../utils";
-import { getRawHtmlConfig, normalizeHtmlConfig } from "../backend/html";
 
 const toolName = "editHtml";
 
@@ -54,13 +53,10 @@ const editHtml = async (
     };
   }
 
-  const backend = normalizeHtmlConfig(getRawHtmlConfig(context));
-
   try {
     const data = await context.app.generateHtml({
       prompt,
       html: currentHtml,
-      backend,
     });
 
     if (data.success && data.html) {

--- a/src/tools/models/editImage.ts
+++ b/src/tools/models/editImage.ts
@@ -34,7 +34,7 @@ const editImage = async (
   if (!context.app?.editImage) {
     return { message: "editImage function not available" };
   }
-  return context.app.editImage(context, prompt);
+  return context.app.editImage(prompt);
 };
 
 export const plugin: ToolPlugin<ImageToolData, unknown, EditImageArgs> = {

--- a/src/tools/models/generateHtml.ts
+++ b/src/tools/models/generateHtml.ts
@@ -3,7 +3,6 @@ import HtmlView from "../views/html.vue";
 import HtmlPreview from "../previews/html.vue";
 import HtmlGenerationConfig from "../configs/HtmlGenerationConfig.vue";
 import type { HtmlToolData } from "../utils";
-import { getRawHtmlConfig, normalizeHtmlConfig } from "../backend/html";
 
 const toolName = "generateHtml";
 
@@ -42,10 +41,8 @@ const generateHtml = async (
     };
   }
 
-  const backend = normalizeHtmlConfig(getRawHtmlConfig(context));
-
   try {
-    const data = await context.app.generateHtml({ prompt, backend });
+    const data = await context.app.generateHtml({ prompt });
 
     if (data.success && data.html) {
       return {

--- a/src/tools/models/setImageStyle.ts
+++ b/src/tools/models/setImageStyle.ts
@@ -1,9 +1,5 @@
 import { ToolPlugin, ToolContext, ToolResult } from "../types";
 import type { ImageGenerationConfigValue } from "@mulmochat-plugin/generate-image";
-import {
-  getRawImageConfig,
-  normalizeImageConfig,
-} from "../backend/imageGeneration";
 import SetImageStylePreview from "../previews/setImageStyle.vue";
 
 const toolName = "setImageStyle";
@@ -49,8 +45,18 @@ const setImageStyleExecute = async (
 ): Promise<ToolResult<SetImageStyleData, SetImageStyleJsonData>> => {
   const { styleModifier } = args;
 
+  if (!context.app?.getImageConfig) {
+    return {
+      message: "getImageConfig function not available",
+      jsonData: {
+        success: false,
+        error: "getImageConfig function not available",
+      },
+    };
+  }
+
   try {
-    const config = normalizeImageConfig(getRawImageConfig(context));
+    const config = context.app.getImageConfig();
     const previousStyleModifier = config.styleModifier;
 
     // Update the config with new style modifier


### PR DESCRIPTION
## 背景・経緯

このPRは、プラグインアーキテクチャにおける設定（config）の取り扱いを改善するリファクタリングです。

### 問題点

以前の実装では、プラグイン（`src/tools/models/`）がバックエンド設定関数（`getRawImageConfig`, `normalizeImageConfig` など）を直接インポートして使用していました。これには以下の問題がありました：

1. **プラグインとバックエンド設定の密結合** - プラグインがバックエンド固有の設定解決ロジックを知っている必要があった
2. **ToolContext の汎用性の低下** - アプリ固有の設定をコンテキストに追加すると、他のアプリでの再利用が難しくなる
3. **設定の一貫性** - 各プラグインが個別に設定を解決するため、設定の適用が分散していた

### 解決策

「バックエンド関数は config を明示的なパラメータとして受け取り、アプリ層が config を解決して context.app 経由でラップ関数を提供する」アーキテクチャを採用しました。

```
[プラグイン] → context.app.generateHtml({ prompt }) 
                    ↓
[アプリ層] config解決 + backend付与 → backendGenerateHtml({ prompt, backend })
                    ↓
[バックエンド] APIコール
```

## 変更内容

### アーキテクチャ変更
- バックエンド関数は config を明示的なパラメータとして受け取る（context から取得しない）
- アプリ層（`useToolResults.ts`）が config を解決し、ラップ関数を `context.app` 経由で提供
- プラグインはバックエンドから config 関数をインポートせず、`context.app` を使用

### 変更ファイル

1. **`src/composables/useToolResults.ts`** - config 解決とラップ関数追加
   - `imageConfig` と `htmlBackend` を解決
   - `context.app.generateHtml` を backend 付きでラップ
   - `context.app.getImageConfig` を追加（setImageStyle 用）

2. **`src/tools/models/editImage.ts`** - バグ修正（余分な `context` 引数を削除）

3. **`src/tools/models/generateHtml.ts`** - backend インポート削除、`context.app.generateHtml({ prompt })` を使用

4. **`src/tools/models/editHtml.ts`** - 同上

5. **`src/tools/models/setImageStyle.ts`** - backend インポート削除、`context.app.getImageConfig()` を使用

6. **`src/tools/backend/index.ts`** - HTML config 関数のエクスポート追加

7. **`src/tools/backend/imageGeneration.ts`** - `ImageGenerationContext` と `ImageGenerationOptions` 型を追加、関数シグネチャ変更

## テスト

- [x] `npm run typecheck` 通過
- [x] `npm run lint` エラーなし（既存の warning のみ）

🤖 Generated with [Claude Code](https://claude.ai/code)