### PR TITLE
Add context.app API for switchRole plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@gui-chat-plugin/scroll-to-anchor": "^0.1.0",
     "@gui-chat-plugin/set-image-style": "^0.1.0",
     "@gui-chat-plugin/spreadsheet": "^0.2.0",
-    "@gui-chat-plugin/switch-role": "^0.1.0",
+    "@gui-chat-plugin/switch-role": "^0.2.0",
     "@gui-chat-plugin/text-response": "^0.1.0",
     "@gui-chat-plugin/todo": "^0.1.0",
     "@gui-chat-plugin/weather": "^0.0.1",

--- a/src/composables/useToolResults.ts
+++ b/src/composables/useToolResults.ts
@@ -24,6 +24,7 @@ import {
 import type { HtmlGenerationParams } from "../tools/backend";
 import type { ImageToolData } from "../tools/utils/imageTypes";
 import type { ToolExecuteFn, GetToolPluginFn } from "../tools/types";
+import { ROLES } from "../config/roles";
 
 // Plugins that are allowed to use setConfig
 const PLUGINS_WITH_SET_CONFIG = ["setImageStyle"];
@@ -41,6 +42,7 @@ interface UseToolResultsOptions {
   scrollToBottomOfSideBar: () => void;
   scrollCurrentResultToTop: () => void;
   onToolCallError?: (toolName: string, error: string) => void;
+  switchRole?: (roleId: string) => void;
 }
 
 interface ToolCallMessage {
@@ -216,6 +218,10 @@ export function useToolResults(
         saveImages,
         // Config accessors for plugins that need to read/modify config
         getImageConfig: () => imageConfig,
+
+        // Role management for switchRole plugin
+        getRoles: () => ROLES.map((r) => ({ id: r.id, name: r.name })),
+        switchRole: options.switchRole ?? (() => {}),
       };
 
       const context: ToolContext = {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -156,6 +156,9 @@ const messages = ref<string[]>([]);
 const currentText = ref("");
 const userInput = ref("");
 
+// Callback for switchRole plugin (set after function definition)
+const switchRoleCallback = ref<((roleId: string) => void) | null>(null);
+
 // Sidebar visibility state (persisted to localStorage)
 const SIDEBAR_VISIBLE_KEY = "sidebar_visible_v1";
 const sidebarVisible = ref<boolean>(
@@ -466,6 +469,9 @@ const {
   onToolCallError: (toolName: string, error: string) => {
     updateToolCallError({ name: toolName }, error);
   },
+  switchRole: (roleId: string) => {
+    switchRoleCallback.value?.(roleId);
+  },
 });
 
 // Wrapper to track results immediately
@@ -651,10 +657,8 @@ async function switchRole(newRoleId: string): Promise<void> {
   await startChat();
 }
 
-// Expose the API globally for external access
-if (typeof window !== "undefined") {
-  (window as any).switchRole = switchRole;
-}
+// Set the switchRole callback for the plugin
+switchRoleCallback.value = switchRole;
 
 watch(
   () => userPreferences.modelKind,

--- a/yarn.lock
+++ b/yarn.lock
@@ -411,9 +411,9 @@
   integrity sha512-Uq7gikcA7lrK3xyZwKPx6au0VcMKXDHbzHjOkuBV/I0RDNWo3qApmF6pTVBVR49WtrKKloN2/a48+8IzPGefLg==
 
 "@graphai/gemini_agent@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@graphai/gemini_agent/-/gemini_agent-2.0.3.tgz#a3d61ad4073e1d216d9021d1cc13993b3171124b"
-  integrity sha512-YvmnSu4rtZRTZnsOKbHahES4Qz9Hiy73D8MWIwmZkgSZHuObd4RtIhbVRWVXfLqKjCgCJ8iYBqXTIiceJI5zDQ==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@graphai/gemini_agent/-/gemini_agent-2.0.4.tgz#6499e0e1a3e4286dac5c03258c56845c777710d8"
+  integrity sha512-KoaODcyYkpZKjVFN6mFimQk4rulZob1oV3igqhPw7waZJMIGC0biCYkzEdLtW+8PIM8cibcB1Roznm34Jsr4AA==
   dependencies:
     "@google/genai" "^1.37.0"
     "@graphai/llm_utils" "^2.0.3"
@@ -603,10 +603,10 @@
   dependencies:
     xlsx "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 
-"@gui-chat-plugin/switch-role@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@gui-chat-plugin/switch-role/-/switch-role-0.1.0.tgz#212063da9689abf4d23af9318b0e37b4cc5c85d1"
-  integrity sha512-98cb9sCgCdj92igdYLf+B1GWCy82lsXFISiC2t6AmN76pAV7G0bwBmGkLeazqsjRTz4hjZISoc/Wk+yfx3oxcQ==
+"@gui-chat-plugin/switch-role@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@gui-chat-plugin/switch-role/-/switch-role-0.2.0.tgz#a06e842b5636fad02b822a90bc73904856bf622d"
+  integrity sha512-yNqZjG+6VGiP1fh+vcxrLJ+YOTMB7HQF9hncJj7l+tTmj8gpvvQ0JiqCoazDxNmW1cb78LWwJn4p8eWCOz37Ig==
 
 "@gui-chat-plugin/text-response@^0.1.0":
   version "0.1.0"
@@ -2386,12 +2386,12 @@ data-uri-to-buffer@^6.0.2:
   integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
 
 data-urls@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-6.0.0.tgz#95a7943c8ac14c1d563b771f2621cc50e8ec7744"
-  integrity sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-6.0.1.tgz#b448c8637997abe34978c9bfdb3d0a7778540184"
+  integrity sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==
   dependencies:
-    whatwg-mimetype "^4.0.0"
-    whatwg-url "^15.0.0"
+    whatwg-mimetype "^5.0.0"
+    whatwg-url "^15.1.0"
 
 debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
@@ -4315,9 +4315,9 @@ netmask@^2.0.2:
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
 node-abi@^3.3.0, node-abi@^3.71.0:
-  version "3.86.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.86.0.tgz#10cb52a8e0f99514076b75ae80a256bdb1735e4c"
-  integrity sha512-sn9Et4N3ynsetj3spsZR729DVlGH6iBG4RiDMV7HEp3guyOW6W3S0unGpLDxT50mXortGUMax/ykUNQXdqc/Xg==
+  version "3.87.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.87.0.tgz#423e28fea5c2f195fddd98acded9938c001ae6dd"
+  integrity sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==
   dependencies:
     semver "^7.3.5"
 
@@ -5903,7 +5903,12 @@ whatwg-mimetype@^4.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
-whatwg-url@^15.0.0, whatwg-url@^15.1.0:
+whatwg-mimetype@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz#d8232895dbd527ceaee74efd4162008fb8a8cf48"
+  integrity sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==
+
+whatwg-url@^15.1.0:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-15.1.0.tgz#5c433439b9a5789eeb3806bbd0da89a8bd40b8d7"
   integrity sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==


### PR DESCRIPTION
## Summary
- Add `getRoles()` and `switchRole()` to `context.app` in useToolResults
- Pass switchRole callback from HomeView to useToolResults  
- Use `createToolDefinition` with ROLES for enum support in tool definition
- Remove global `window.switchRole`, use callback pattern instead

## Related
- GUIChatPluginSwitchRole branch: `context-api`

## Test plan
- [ ] Test switchRole plugin works with new context API
- [ ] Verify role enum appears in tool definition
- [ ] Confirm role switching disconnects and reconnects properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added role-switching functionality enabling users to seamlessly change between available roles within the application.

* **Chores**
  * Updated switch-role plugin dependency to the latest version for improved functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->