### PR TITLE
Fix UUID preservation when updating tool results

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -228,10 +228,17 @@ export const toolExecute: ToolExecuteFn = async (context, name, args) => {
     throw new Error(`Plugin ${name} not found`);
   }
   const result = await plugin.execute(context, args);
+
+  // When updating existing result, preserve the original UUID to avoid race conditions
+  const uuid =
+    result.updating && context.currentResult?.uuid
+      ? context.currentResult.uuid
+      : result.uuid || uuidv4();
+
   return {
     ...result,
     toolName: result.toolName ?? name,
-    uuid: result.uuid || uuidv4(),
+    uuid,
   };
 };
 


### PR DESCRIPTION
When a plugin returns `updating: true`, preserve the original UUID from context.currentResult to avoid race conditions with parallel tool calls. Previously, each tool call would generate a new UUID even when updating, causing "Failed to find the result to update" errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UUID preservation when updating existing tool results to maintain consistent identifiers across updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->