### PR TITLE
Fix text session sending intermediate messages during tool execution

### DIFF
--- a/src/composables/useTextSession.ts
+++ b/src/composables/useTextSession.ts
@@ -383,7 +383,9 @@ export function useTextSession(
     return true;
   };
 
-  const isDataChannelOpen = () => !conversationActive.value;
+  // For text sessions, always return false to prevent intermediate messages
+  // OpenAI's Chat API requires all tool responses before any other messages
+  const isDataChannelOpen = () => false;
 
   const setMute = (muted: boolean) => {
     isMuted.value = muted;


### PR DESCRIPTION
## Problem

In text sessions, when tools are processed asynchronously after the API response, `conversationActive` becomes `false` (set in finally block) while tool execution is still ongoing. 

This caused `isDataChannelOpen()` to return `true`, allowing `waitingMessage` to be sent via `sendInstructions()`.

```
Text Session flow:
1. conversationActive = true
2. API call
3. Response received
4. handlers.onToolCall() called for each tool (synchronous)
5. conversationActive = false (finally block)
6. Tool execution continues asynchronously
   ↑ isDataChannelOpen() returns true here, waitingMessage sent
   → OpenAI Chat API error
```

This violates OpenAI's Chat Completion API requirement that all tool responses must be sent before any other messages.

## Fix

For text sessions, always return `false` from `isDataChannelOpen()` to prevent any intermediate messages (`waitingMessage`, `uploadMessage`) from being sent during the session.

## Test plan

- [ ] Test text session with plugins that have `waitingMessage` defined
- [ ] Verify no API errors occur during tool execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data channel behavior in text sessions to ensure consistent and reliable message transmission throughout conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->