### PR TITLE
fix: make tool calls sequential with async/await

### DIFF
--- a/src/composables/useGoogleLiveSession.ts
+++ b/src/composables/useGoogleLiveSession.ts
@@ -223,7 +223,7 @@ export function useGoogleLiveSession(
         const argStr = JSON.stringify(fixedArgs);
 
         // Call handler immediately - don't store in pendingToolCalls since we're handling it now
-        handlers.onToolCall?.(toolCallMsg, callId, argStr);
+        await handlers.onToolCall?.(toolCallMsg, callId, argStr);
 
         // Store ONLY for sendFunctionCallOutput to retrieve the name later
         pendingToolCalls.set(callId, {
@@ -291,7 +291,7 @@ export function useGoogleLiveSession(
 
             const argStr = JSON.stringify(functionCall.args || {});
             processedToolCalls.add(callId);
-            handlers.onToolCall?.(toolCallMsg, callId, argStr);
+            await handlers.onToolCall?.(toolCallMsg, callId, argStr);
           }
         }
 

--- a/src/composables/useRealtimeSession.ts
+++ b/src/composables/useRealtimeSession.ts
@@ -5,7 +5,11 @@ import { isValidToolCallMessage } from "./types";
 import { DEFAULT_REALTIME_MODEL_ID } from "../config/models";
 
 export interface RealtimeSessionEventHandlers {
-  onToolCall?: (msg: ToolCallMessage, id: string, argStr: string) => void;
+  onToolCall?: (
+    msg: ToolCallMessage,
+    id: string,
+    argStr: string,
+  ) => void | Promise<void>;
   onTextDelta?: (delta: string) => void;
   onTextCompleted?: () => void;
   onConversationStarted?: () => void;
@@ -94,7 +98,7 @@ export function useRealtimeSession(
     return true;
   };
 
-  const handleMessage = (event: MessageEvent) => {
+  const handleMessage = async (event: MessageEvent) => {
     let msg: ToolCallMessage;
 
     try {
@@ -148,7 +152,7 @@ export function useRealtimeSession(
         }
         console.log(`MSG: toolcall\n${argStr}`);
         processedToolCalls.set(id, argStr);
-        handlers.onToolCall?.(msg, id, argStr);
+        await handlers.onToolCall?.(msg, id, argStr);
         break;
       }
       case "response.created":

--- a/src/composables/useTextSession.ts
+++ b/src/composables/useTextSession.ts
@@ -217,7 +217,7 @@ export function useTextSession(
       // Handle tool calls if present
       if (toolCalls && toolCalls.length > 0) {
         for (const toolCall of toolCalls) {
-          handlers.onToolCall?.(
+          await handlers.onToolCall?.(
             {
               type: "response.function_call_arguments.done",
               name: toolCall.name,

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -518,7 +518,7 @@ const isListenerMode = computed(() => userPreferences.roleId === "listener");
 const lastSpeechStartedTime = ref<number | null>(null);
 
 registerEventHandlers({
-  onToolCall: (msg, id, argStr) => {
+  onToolCall: async (msg, id, argStr) => {
     // Track tool call in history for debugging
     const toolName = typeof msg === "string" ? msg : msg.name || "unknown";
     try {
@@ -527,7 +527,7 @@ registerEventHandlers({
     } catch {
       addToolCallToHistory(toolName, argStr);
     }
-    void handleToolCall({ msg, rawArgs: argStr });
+    await handleToolCall({ msg, rawArgs: argStr });
   },
   onTextDelta: (delta) => {
     currentText.value += delta;


### PR DESCRIPTION
## Summary
- Make tool call handlers sequential instead of parallel using async/await
- Prevents race conditions when LLM returns multiple tool calls in a single response

## Background
When LLM returns multiple tool calls in a single response, they were previously processed in parallel (using `void handleToolCall()`). This caused race conditions where:
1. Multiple tool calls could update the same result simultaneously
2. Tool results could be sent back to LLM in unpredictable order
3. For plugins with `updating: true`, later calls could overwrite earlier results

## Changes
- Change `onToolCall` handler signature to return `void | Promise<void>`
- Make `handleMessage`/`handleWebSocketMessage` handlers async
- Use `await handlers.onToolCall()` to process tool calls sequentially
- Update `HomeView.vue` to use async handler and await `handleToolCall`

## Test plan
- [ ] Test with plugins that return `updating: true` (e.g., MindMap)
- [ ] Verify tool calls are processed in order
- [ ] Verify no race conditions in result updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced tool call error handling through improved execution sequencing

* **Improvements**
  * Tool calls now execute sequentially with proper completion tracking
  * Tool arguments are parsed as structured JSON format when available for better data handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->