### PR TITLE
feat: add MindMap plugin and Brainstorm role

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@gui-chat-plugin/html": "^0.1.0",
     "@gui-chat-plugin/map": "^0.1.0",
     "@gui-chat-plugin/markdown": "^0.0.1",
+    "@gui-chat-plugin/mindmap": "github:receptron/GUIChatPluginMindMap",
     "@gui-chat-plugin/mulmocast": "^0.0.2",
     "@gui-chat-plugin/music": "^0.0.1",
     "@gui-chat-plugin/othello": "^0.2.0",

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -288,6 +288,36 @@ export const ROLES: Role[] = [
       "IMPORTANT: Always create presentations in the user's native language. Keep narration concise and impactful. Ensure each beat flows naturally to the next, creating a cohesive story arc. Make image prompts detailed and evocative to generate compelling visuals.\n" +
       "Make it sure that the text is EASY TO UNDERSTAND for middle school students. If the text is too difficult, you should explain it in a way that is easy to understand for middle school students.\n",
   },
+  {
+    id: "brainstorm",
+    name: "Brainstorm",
+    icon: "lightbulb",
+    includePluginPrompts: true,
+    pluginMode: "fixed",
+    availablePlugins: [
+      "createMindMap",
+      "generateImage",
+      "presentDocument",
+      "searchWeb",
+      "browse",
+      "switchRole",
+    ],
+    prompt:
+      "You are a creative brainstorming facilitator who helps users visualize and explore their ideas. Your role is to spark creativity and help organize thoughts visually.\n\n" +
+      "WORKFLOW:\n" +
+      "1. When users want to brainstorm ideas, use createMindMap to organize concepts hierarchically and show relationships\n" +
+      "2. Use generateImage to create custom visuals that represent key concepts\n" +
+      "3. Use presentDocument to summarize brainstorming sessions and create action plans\n\n" +
+      "INTERACTION STYLE:\n" +
+      "- Be enthusiastic and encouraging about all ideas - no idea is too wild!\n" +
+      "- Ask probing questions to help users dig deeper into their concepts\n" +
+      "- Suggest unexpected connections between ideas\n" +
+      "- When users click on nodes in mind maps, expand on those concepts\n" +
+      "- Celebrate creative breakthroughs and help users see the value in their ideas\n\n" +
+      "TIPS:\n" +
+      "- Use mind maps for structured ideation (projects, plans, topics)\n" +
+      "- Always visualize - don't just talk about ideas, show them!",
+  },
 ];
 
 export const DEFAULT_ROLE_ID = "general";

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import "@gui-chat-plugin/edit-html/style.css";
 import "@gui-chat-plugin/switch-role/style.css";
 import "@gui-chat-plugin/set-image-style/style.css";
 import "@gui-chat-plugin/scroll-to-anchor/style.css";
+import "@gui-chat-plugin/mindmap/style.css";
 import "guichat-plugin-akinator/style.css";
 
 createApp(App).use(router).mount("#app");

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,6 +37,7 @@ import EditHtmlPlugin from "@gui-chat-plugin/edit-html/vue";
 import SwitchRolePlugin from "@gui-chat-plugin/switch-role/vue";
 import SetImageStylePlugin from "@gui-chat-plugin/set-image-style/vue";
 import ScrollToAnchorPlugin from "@gui-chat-plugin/scroll-to-anchor/vue";
+import MindMapPlugin from "@gui-chat-plugin/mindmap/vue";
 import AkinatorPlugin from "guichat-plugin-akinator/vue";
 
 const pluginList = [
@@ -68,6 +69,7 @@ const pluginList = [
   SwitchRolePlugin,
   SetImageStylePlugin,
   ScrollToAnchorPlugin,
+  MindMapPlugin,
   AkinatorPlugin,
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,12 @@
     gui-chat-protocol "^0.0.1"
     marked "^15.0.0"
 
+"@gui-chat-plugin/mindmap@github:receptron/GUIChatPluginMindMap":
+  version "0.1.3"
+  resolved "https://codeload.github.com/receptron/GUIChatPluginMindMap/tar.gz/5de78416d6fd37768f6fe00b69c4b8ab5cdf77e9"
+  dependencies:
+    gui-chat-protocol "^0.0.3"
+
 "@gui-chat-plugin/mulmocast@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@gui-chat-plugin/mulmocast/-/mulmocast-0.0.2.tgz#d9263a2b599f7d580e99637024865ffdde8fd504"


### PR DESCRIPTION
## Summary
- Add @gui-chat-plugin/mindmap from GitHub (receptron/GUIChatPluginMindMap)
- Register MindMapPlugin in tools/index.ts
- Add mindmap style import in main.ts
- Add new "Brainstorm" role for creative ideation with mind maps

## Brainstorm Role
The new role provides a creative facilitator experience with access to:
- `createMindMap` - Organize concepts hierarchically and show relationships
- `generateImage` - Create custom visuals for key concepts
- `presentDocument` - Summarize brainstorming sessions
- `searchWeb` - Research topics
- `browse` - View web content
- `switchRole` - Switch to other roles

## Test plan
- [ ] Verify MindMap plugin loads correctly
- [ ] Test Brainstorm role selection
- [ ] Create mind maps and verify visualization works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Introduced new Brainstorm role designed for creative ideation and visual thinking
- Integrated mind mapping capabilities to organize ideas and visualize concept relationships
- Brainstorm includes image generation, document presentation, and research tools for comprehensive creative collaboration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->