### PR TITLE
Fix TypeScript type errors in piano plugin integration

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import type {
   BackendType,
   FileInputHandler,
   ClipboardImageInputHandler,
+  InputHandler,
 } from "gui-chat-protocol/vue";
 import { v4 as uuidv4 } from "uuid";
 import { getRole, ROLES } from "../config/roles";
@@ -260,11 +261,11 @@ export const getToolPlugin: GetToolPluginFn = (name) => {
 export const getFileInputPlugins = () => {
   return pluginList
     .filter((plugin) =>
-      plugin.plugin.inputHandlers?.some((h) => h.type === "file"),
+      plugin.plugin.inputHandlers?.some((h: InputHandler) => h.type === "file"),
     )
     .map((plugin) => {
       const fileHandler = plugin.plugin.inputHandlers!.find(
-        (h) => h.type === "file",
+        (h: InputHandler) => h.type === "file",
       )!;
       return {
         toolName: plugin.plugin.toolDefinition.name,
@@ -279,11 +280,11 @@ export const getFileInputPlugins = () => {
 export const getClipboardImagePlugins = () => {
   return pluginList
     .filter((plugin) =>
-      plugin.plugin.inputHandlers?.some((h) => h.type === "clipboard-image"),
+      plugin.plugin.inputHandlers?.some((h: InputHandler) => h.type === "clipboard-image"),
     )
     .map((plugin) => {
       const handler = plugin.plugin.inputHandlers!.find(
-        (h) => h.type === "clipboard-image",
+        (h: InputHandler) => h.type === "clipboard-image",
       )!;
       return {
         toolName: plugin.plugin.toolDefinition.name,

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,7 @@
   resolved "https://codeload.github.com/receptron/GUIChatPluginMindMap/tar.gz/ba841f45e1c2c359b54dc4deb2c49685142fbb8b"
   dependencies:
     gui-chat-protocol "^0.0.3"
+    jspdf "^4.0.0"
 
 "@gui-chat-plugin/mulmocast@^0.0.3":
   version "0.0.3"
@@ -593,7 +594,7 @@
 
 "@gui-chat-plugin/piano@github:receptron/GUIChatPluginPiano":
   version "0.1.0"
-  resolved "https://codeload.github.com/receptron/GUIChatPluginPiano/tar.gz/33b6c1575a35d5fb98ef519879a6ad09191acf32"
+  resolved "https://codeload.github.com/receptron/GUIChatPluginPiano/tar.gz/166821d095217f7c788ce600048e5cd688751240"
   dependencies:
     gui-chat-protocol "^0.0.3"
     openai "^4.77.0"


### PR DESCRIPTION
## 概要
Pianoプラグイン統合時のTypeScriptの型エラーを修正しました。

## 変更内容
- `InputHandler` 型を `gui-chat-protocol/vue` からインポート
- `getFileInputPlugins()` と `getClipboardImagePlugins()` 内のラムダ関数のパラメータに明示的な型アノテーション `(h: InputHandler)` を追加
- Pianoプラグインの更新版（`.gitignore`から`dist/`を削除したバージョン）を参照するよう`yarn.lock`を更新

## 修正した問題
Pianoプラグインを追加した際、`inputHandlers`の型推論が正しく行われず、TypeScriptのコンパイルエラーが発生していました。明示的に`InputHandler`型を指定することで、型チェックが通るようになりました。

## 関連
- Pianoプラグイン側で`.gitignore`から`dist/`を削除し、GitHubインストール時に`dist`フォルダが正しく含まれるよう修正済み