### PR TITLE
feat: add drawing-game plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@gui-chat-plugin/mulmocast": "^0.0.3",
     "@gui-chat-plugin/music": "^0.0.2",
     "@gui-chat-plugin/othello": "^0.2.2",
+    "@gui-chat-plugin/drawing-game": "github:receptron/GUIChatPluginDrawingGame#main",
     "@gui-chat-plugin/piano": "github:receptron/GUIChatPluginPiano",
     "@gui-chat-plugin/present3d": "^0.0.3",
     "@gui-chat-plugin/scroll-to-anchor": "^0.1.1",

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -235,6 +235,7 @@ export const ROLES: Role[] = [
       "playOthello",
       "playGo",
       "playPiano",
+      "drawingGame",
       "putQuestions",
       "akinator_game",
       "generateHtml",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -40,6 +40,7 @@ import SetImageStylePlugin from "@gui-chat-plugin/set-image-style/vue";
 import ScrollToAnchorPlugin from "@gui-chat-plugin/scroll-to-anchor/vue";
 import MindMapPlugin from "@gui-chat-plugin/mindmap/vue";
 import PianoPlugin from "@gui-chat-plugin/piano/vue";
+import DrawingGamePlugin from "@gui-chat-plugin/drawing-game/vue";
 import AkinatorPlugin from "guichat-plugin-akinator/vue";
 
 const pluginList = [
@@ -73,6 +74,7 @@ const pluginList = [
   ScrollToAnchorPlugin,
   MindMapPlugin,
   PianoPlugin,
+  DrawingGamePlugin,
   AkinatorPlugin,
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,6 +500,12 @@
   dependencies:
     vue-drawing-canvas "^1.0.14"
 
+"@gui-chat-plugin/drawing-game@github:receptron/GUIChatPluginDrawingGame#main":
+  version "0.1.0"
+  resolved "https://codeload.github.com/receptron/GUIChatPluginDrawingGame/tar.gz/77b9c4a71ffc0e7dafc2eac2554b73d85f37adc3"
+  dependencies:
+    gui-chat-protocol "^0.0.3"
+
 "@gui-chat-plugin/edit-html@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@gui-chat-plugin/edit-html/-/edit-html-0.1.1.tgz#cd037a791b18149c65e77ecea3ef0aad2a4859b3"


### PR DESCRIPTION
## Summary

- Add @gui-chat-plugin/drawing-game plugin for drawing with primitives and AI guessing
- Add drawingGame to Game role's availablePlugins

## Test plan

- [ ] Run `yarn dev` and test drawing game with voice/chat instructions
- [ ] Verify Game role includes the drawing game plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a drawing game plugin, now available for use in the game role.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->