### PR TITLE
fix: add quiet option to dotenv.config()

### DIFF
--- a/benchmark/src/config.ts
+++ b/benchmark/src/config.ts
@@ -14,7 +14,7 @@ import type { BenchmarkConfig, LLMConfig } from "./types";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "../..");
-dotenv.config({ path: path.join(rootDir, ".env") });
+dotenv.config({ path: path.join(rootDir, ".env"), quiet: true });
 
 /**
  * Get API key from environment variable

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -11,7 +11,7 @@ import htmlRouter from "./html";
 import textRouter from "./textLLM";
 import comfyRouter from "./comfyui";
 import imageRouter from "./image";
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const router: Router = express.Router();
 

--- a/server/routes/html.ts
+++ b/server/routes/html.ts
@@ -4,7 +4,7 @@ import { GoogleGenAI } from "@google/genai";
 import dotenv from "dotenv";
 import { sendApiError, logApiRequest } from "../utils/logger";
 
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const router: Router = express.Router();
 

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -3,7 +3,7 @@ import dotenv from "dotenv";
 import { GoogleGenAI } from "@google/genai";
 import { Buffer } from "node:buffer";
 import { sendApiError, logApiRequest } from "../utils/logger";
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const router: Router = express.Router();
 

--- a/server/routes/pdf.ts
+++ b/server/routes/pdf.ts
@@ -8,7 +8,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import dotenv from "dotenv";
 import { sendApiError } from "../utils/logger";
 
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const router: Router = express.Router();
 

--- a/server/tests/test-comfyui.ts
+++ b/server/tests/test-comfyui.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 

--- a/server/tests/test-image-openai.ts
+++ b/server/tests/test-image-openai.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 

--- a/server/tests/test-opencanvas-anthropic.ts
+++ b/server/tests/test-opencanvas-anthropic.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-opencanvas-google-clear.ts
+++ b/server/tests/test-opencanvas-google-clear.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-opencanvas-google-debug.ts
+++ b/server/tests/test-opencanvas-google-debug.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-opencanvas-google-explicit.ts
+++ b/server/tests/test-opencanvas-google-explicit.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-opencanvas-google.ts
+++ b/server/tests/test-opencanvas-google.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-opencanvas-ollama.ts
+++ b/server/tests/test-opencanvas-ollama.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-opencanvas.ts
+++ b/server/tests/test-opencanvas.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-text-anthropic.ts
+++ b/server/tests/test-text-anthropic.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-text-google.ts
+++ b/server/tests/test-text-google.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-text-ollama.ts
+++ b/server/tests/test-text-ollama.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-text-openai.ts
+++ b/server/tests/test-text-openai.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-tools-anthropic.ts
+++ b/server/tests/test-tools-anthropic.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-tools-google.ts
+++ b/server/tests/test-tools-google.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-tools-ollama.ts
+++ b/server/tests/test-tools-ollama.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 

--- a/server/tests/test-tools-openai.ts
+++ b/server/tests/test-tools-openai.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 
 const BASE_URL = process.env.TEST_SERVER_URL ?? "http://localhost:3001";
 


### PR DESCRIPTION
## Summary
- Add `quiet: true` option to all `dotenv.config()` calls
- Suppress warning messages when `.env` file is not present

## Changes
- `server/routes/`: 4 files
- `server/tests/`: 17 files
- `benchmark/src/config.ts`: 1 file

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Suppressed environment variable loading logs during application startup and testing to reduce console output noise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->