### PR TITLE
Replace deprecated `substr`

### DIFF
--- a/server/llm/providers/google.ts
+++ b/server/llm/providers/google.ts
@@ -100,7 +100,7 @@ function extractToolCallsFromCandidates(candidates: unknown): ToolCall[] {
     for (const part of parts) {
       if (part?.functionCall) {
         const toolCall: ToolCall = {
-          id: `call_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          id: `call_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
           name: part.functionCall.name || "",
           arguments: JSON.stringify(part.functionCall.args),
         };


### PR DESCRIPTION
Resolves #157.

[1] https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/substr