### PR TITLE
fix: replace deprecated substr in ollama provider

### DIFF
--- a/server/llm/providers/ollama.ts
+++ b/server/llm/providers/ollama.ts
@@ -166,7 +166,7 @@ export async function generateWithOllama(
   if (data.message?.tool_calls && data.message.tool_calls.length > 0) {
     for (const tc of data.message.tool_calls) {
       toolCalls.push({
-        id: `call_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        id: `call_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
         name: tc.function.name,
         arguments: JSON.stringify(tc.function.arguments),
       });


### PR DESCRIPTION
## Summary
Follow-up to #158. The same deprecated `String.prototype.substr()` pattern remained in `server/llm/providers/ollama.ts`.

`substr(2, 9)` → `substring(2, 11)` (both return 9 chars starting at index 2, equivalent behavior).

Resolves #157.

## Test plan
- [x] `yarn lint` passes
- [x] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the tool call identifier generation format for Ollama integration, improving the reliability of tool call identification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/MulmoChat/pull/164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->