### PR TITLE
chore: bump GitHub Actions to latest + Node 24

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
Mechanical bump of GitHub Actions to current latest and (where applicable) extend Node matrix to include 24.x. See commit message for details. Auto-generated across receptron/* + isamu/* source repos. CI on this PR is the verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request workflow to use a newer checkout action version in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->