### PR TITLE
chore: update lint/format tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "autoprefixer": "^10.5.4",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.0",
-    "eslint-config-prettier": "^10.0.1",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-sonarjs": "^4.2.0",
     "globals": "^17.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,7 +3057,7 @@ escape-string-regexp@^5.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
-eslint-config-prettier@^10.0.1:
+eslint-config-prettier@^10.1.8:
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==


### PR DESCRIPTION
## Summary

Bumps a single dev-tooling dependency to its latest patch:

- `eslint-config-prettier` `^10.0.1` → `^10.1.8` (devDependencies)

The resolved version in the lockfile was already `10.1.8` (it satisfied the old `^10.0.1` range), so the only lockfile change is the constraint key. No transitive dependencies moved. No other tools, `typescript`, `@eslint/js`, or new packages were touched.

Verified from a clean install (`rm -rf node_modules && yarn install --frozen-lockfile`):
- `yarn lint` — pass
- `yarn build` (vite build + tsc server) — pass
- `yarn typecheck` (vue-tsc --noEmit) — pass
- `yarn test` — no plain `test` script defined (only `test:*` variants requiring API keys), skipped

## Items to Confirm / Review

- Single-line constraint bump; lockfile diff is 1 line (constraint key only, resolved version unchanged).
- No source edits were required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code formatting configuration dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->